### PR TITLE
Allow jetson.fan to be empty

### DIFF
--- a/scripts/jetson_stats.py
+++ b/scripts/jetson_stats.py
@@ -132,7 +132,7 @@ class ROSJtop:
         if power:
             self.arr.status += [power_status(self.hardware, total, power)]
         # Fan controller
-        if jetson.fan is not None:
+        if jetson.fan:
             self.arr.status += [fan_status(self.hardware, jetson.fan, 'board')]
         # Status board and board info
         self.arr.status += [self.board_status]


### PR DESCRIPTION
This fixes the case where a board can have no fan, the `jetson.fan` object returned is simply an empty dictionary `{}`. The condition will behave the same if jetson.fan is `None`.

Otherwise the callback silently fails and blocks forever (internally there is an exception `Exception: 'measure'`).