### PR TITLE
Add Fan speed to fan service in case manual mode is selected.

### DIFF
--- a/scripts/jetson_stats.py
+++ b/scripts/jetson_stats.py
@@ -89,8 +89,11 @@ class ROSJtop:
     def fan_service(self, req):
         # Try to set new nvpmodel
         fan_mode = req.mode
+        fan_speed = req.fanSpeed
         try:
             self.jetson.fan.mode = fan_mode
+            if fan_mode == "manual":
+                self.jetson.fan.speed = fan_speed
         except jtop.JtopException as e:
             rospy.logerr(e)
             # Return same nvp model

--- a/srv/fan.srv
+++ b/srv/fan.srv
@@ -1,5 +1,6 @@
 # fan selection
 
 string mode
+int8 fanSpeed
 ---
 string done


### PR DESCRIPTION
In the fan service there was no way to set the speed of the fan in case manual mode is selected. I needed this in order to force the fan to an arbitrary speed.